### PR TITLE
fix(week_digest): fix remaining redundant break statement

### DIFF
--- a/weekly_digest.go
+++ b/weekly_digest.go
@@ -107,7 +107,6 @@ func formatWords() string {
 		lastStr = "3 weeks"
 	case 30:
 		lastStr = "months"
-		break
 	default:
 		lastStr = fmt.Sprintf("%d days", *interval)
 	}


### PR DESCRIPTION
Add a CodeLingo Tenet to protect the code from future instances of redundant break statements fixed in [this PR #19](https://github.com/yangwenmai/weekly_digest/pull/19/files#diff-d35170d6b6f8469b505469b7c286a266R110). Use the Tenet to find and fix several remaining cases of the issue.